### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,10 @@ env:
 
 on:
   push:
-    branches: '*'
-    tags: 'v*'
+    branches:
+      - '*'
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - master
@@ -74,12 +76,12 @@ jobs:
       - name: Extract Version
         id: version
         if: startsWith(github.ref, 'refs/tags/v')
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Create Release
         id: create_release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: NetBSD ${{ steps.version.outputs.VERSION }}
           draft: true


### PR DESCRIPTION
Fix warnings:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: softprops/action-gh-release@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

And a minor syntax fix around "push branches/tags"